### PR TITLE
Update bootstrap to find the nfs location from the ApplicationType tag

### DIFF
--- a/ansible/roles/lifecycle-scripts/files/boot-strap.sh
+++ b/ansible/roles/lifecycle-scripts/files/boot-strap.sh
@@ -1,43 +1,47 @@
 #!/bin/bash
 
-### Script to start WebLogic Admin and Managed Servers using Docker Compose.  
-### Requires values passed in from AMI and AWS cli commands   
-### Function is to retrieve correct config, build server directory structure, pass App versions to docker-compose, etc. 
-### Required meta data: 
-### - Code versions  
-### - Shared config buckert address
-### - Environment (Live, Stage, Dev)
-### - Instance (Server1 or 2, etc.)
+### Script to start Docker containers using Docker Compose.
+### Requires values to be supplied as tags on the EC2 instance where it runs:
+###   Application  (the name of the application type - e.g. cics or chips etc)
+###   app-instance-name  (the name of the application instance type - e.g. cics1 or chips-ef-batch1 etc)
+###   config-base-path (the S3 path to where the config is stored - e.g. s3://shared-services.eu-west-2.configs.ch.gov.uk/cic-configs/development etc)
+### The tags are defined in terraform code and set as values on the launch configuration that is used by the Auto Scaling Group to create EC2 instances.
 
-exec >> ~/start-up.log 2>&1
-echo " ~~~~~~~~~ Starting Docker Compose wrapper script: `date -u "+%F %T"`" 
+exec > >(tee -ai ~/start-up.log) 2>&1
+echo " ~~~~~~~~~ Starting Docker Compose wrapper script: `date -u "+%F %T"`"
 set -a
 
-# WL Server parent directory name 
-INSTANCE_DIR="/mnt/nfs/cics"
+NFS_MOUNT_LOCATION="/mnt/nfs"
 EC2_REGION=$( ec2-metadata -z | awk '{print $2}' | sed 's/[a-z]$//' )
 
-# Get EC2_INSTANCE_ID - example server1, server2, etc.
+# Get EC2_INSTANCE_ID
 EC2_INSTANCE_ID=$( ec2-metadata -i |  awk -F'[: ]' '{print $3}' )
-echo "EC2_INSTANCE_ID=${EC2_INSTANCE_ID}" 
+echo "EC2_INSTANCE_ID=${EC2_INSTANCE_ID}"
 
-# Get TAG passed in via AMI, terraform, build, etc 
+# Get Application TAG from EC2 instance
+APP_NAME=$( aws ec2 describe-tags --filters "Name=resource-id,Values=${EC2_INSTANCE_ID}" --region ${EC2_REGION} --output text|grep Application|  awk '{print $5}' | tr '[:upper:]' '[:lower:]' )
+echo "APP_NAME=${APP_NAME}"
+
+INSTANCE_DIR=${NFS_MOUNT_LOCATION}/${APP_NAME}
+echo "INSTANCE_DIR=${INSTANCE_DIR}"
+
+# Get app-instance-name TAG from EC2 instance
 APP_INSTANCE_NAME=$( aws ec2 describe-tags --filters "Name=resource-id,Values=${EC2_INSTANCE_ID}" --region ${EC2_REGION} --output text|grep app-instance-name|  awk '{print $5}' )
-echo "APP_INSTANCE_NAME=${APP_INSTANCE_NAME}" 
+echo "APP_INSTANCE_NAME=${APP_INSTANCE_NAME}"
 
-# Get confog base path
+# Get config base path
 CONFIG_BASE_PATH=$( aws ec2 describe-tags --filters "Name=resource-id,Values=${EC2_INSTANCE_ID}" --region ${EC2_REGION} --output text|grep config-base-path|  awk '{print $5}' )
-echo "CONFIG_BASE_PATH=${CONFIG_BASE_PATH}" 
+echo "CONFIG_BASE_PATH=${CONFIG_BASE_PATH}"
 
-# Check S3 and Config can be reached 
+# Check S3 and Config can be reached
 aws s3 ls ${CONFIG_BASE_PATH} >/dev/null
 
 if (( $? != 0 )) ; then
-  echo "ERROR - S3 or Config can not be found. Exit. " 
+  echo "ERROR - S3 or Config can not be found. Exit. "
   exit 1
 fi
 
-# create server instance directory 
+# create server instance directory
 mkdir -p ${INSTANCE_DIR}/${APP_INSTANCE_NAME}/running-servers
 cd ${INSTANCE_DIR}/${APP_INSTANCE_NAME}
 
@@ -45,12 +49,12 @@ cd ${INSTANCE_DIR}/${APP_INSTANCE_NAME}
 aws s3 cp ${CONFIG_BASE_PATH}/ ./ --recursive --exclude "*/*"
 aws s3 cp ${CONFIG_BASE_PATH}/${APP_INSTANCE_NAME}/ ./ --recursive --exclude "*/*"
 
-# Get and source application versions to use for Docker Compose 
+# Get and source application versions to use for Docker Compose
 # CIC_APACHE_IMAGE
 # CIC_APP_IMAGE
 . app-image-versions
 
-echo "`env`" | grep IMAGE 
+echo "`env`" | grep IMAGE
 
 # Get ECR Repo details and log into ECR
 AWS_ECR_REPO_DOMAIN=amazonaws.com
@@ -65,5 +69,5 @@ done
 set +a
 
 ### RUN DOCKER COMPOSE
-echo "Starting docker compose file ..." 
+echo "Starting docker compose file ..."
 docker-compose up -d

--- a/ansible/roles/lifecycle-scripts/files/boot-strap.sh
+++ b/ansible/roles/lifecycle-scripts/files/boot-strap.sh
@@ -2,7 +2,7 @@
 
 ### Script to start Docker containers using Docker Compose.
 ### Requires values to be supplied as tags on the EC2 instance where it runs:
-###   Application  (the name of the application type - e.g. cics or chips etc)
+###   ApplicationType  (the name of the application type - e.g. cics or chips etc)
 ###   app-instance-name  (the name of the application instance type - e.g. cics1 or chips-ef-batch1 etc)
 ###   config-base-path (the S3 path to where the config is stored - e.g. s3://shared-services.eu-west-2.configs.ch.gov.uk/cic-configs/development etc)
 ### The tags are defined in terraform code and set as values on the launch configuration that is used by the Auto Scaling Group to create EC2 instances.
@@ -18,8 +18,8 @@ EC2_REGION=$( ec2-metadata -z | awk '{print $2}' | sed 's/[a-z]$//' )
 EC2_INSTANCE_ID=$( ec2-metadata -i |  awk -F'[: ]' '{print $3}' )
 echo "EC2_INSTANCE_ID=${EC2_INSTANCE_ID}"
 
-# Get Application TAG from EC2 instance
-APP_NAME=$( aws ec2 describe-tags --filters "Name=resource-id,Values=${EC2_INSTANCE_ID}" --region ${EC2_REGION} --output text|grep Application|  awk '{print $5}' | tr '[:upper:]' '[:lower:]' )
+# Get ApplicationType TAG from EC2 instance
+APP_NAME=$( aws ec2 describe-tags --filters "Name=resource-id,Values=${EC2_INSTANCE_ID}" --region ${EC2_REGION} --output text|grep ApplicationType|  awk '{print $5}' | tr '[:upper:]' '[:lower:]' )
 echo "APP_NAME=${APP_NAME}"
 
 INSTANCE_DIR=${NFS_MOUNT_LOCATION}/${APP_NAME}


### PR DESCRIPTION
This allows the boot-strap.sh script to be used for CICS and CHIPS etc, as the NFS mount location is now derived from the Application tag.  Also tidied up some comments and made stdout go to the screen as well as the log.