### PR TITLE
Install chrony to synchronise the clock

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -4,6 +4,7 @@
   gather_facts: yes
   roles:
     - docker
+    - chrony
     - lifecycle-scripts
     - ch_collections.base.nagios_nrpe_client
     - name: ch_collections.heritage_services.nfs

--- a/ansible/roles/chrony/tasks/main.yml
+++ b/ansible/roles/chrony/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: install chrony using yum
+  yum:
+    name: chrony
+    state: latest
+
+- name: service chronyd
+  service:
+    name: chronyd
+    state: started
+    enabled: yes


### PR DESCRIPTION
There is no time synchronisation enabled on the docker-ami EC2 instances, so this installs chrony to correct the time.

Resolves: https://companieshouse.atlassian.net/browse/CM-1323