### PR TITLE
CM-1401 add support for setting crontab from S3

### DIFF
--- a/ansible/roles/lifecycle-scripts/files/set-aws-vars.sh
+++ b/ansible/roles/lifecycle-scripts/files/set-aws-vars.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+### Script to set variables used by bootstrap and similar scripts
+### Requires values to be supplied as tags on the EC2 instance where it runs:
+###   ApplicationType  (the name of the application type - e.g. cics or chips etc)
+###   app-instance-name  (the name of the application instance type - e.g. cics1 or chips-ef-batch1 etc)
+###   config-base-path (the S3 path to where the config is stored - e.g. s3://shared-services.eu-west-2.configs.ch.gov.uk/cic-configs/development etc)
+### The tags are defined in terraform code and set as values on the launch configuration that is used by the Auto Scaling Group to create EC2 instances.
+
+NFS_MOUNT_LOCATION="/mnt/nfs"
+EC2_REGION=$( ec2-metadata -z | awk '{print $2}' | sed 's/[a-z]$//' )
+
+# Get EC2_INSTANCE_ID
+EC2_INSTANCE_ID=$( ec2-metadata -i |  awk -F'[: ]' '{print $3}' )
+echo "EC2_INSTANCE_ID=${EC2_INSTANCE_ID}"
+
+# Get ApplicationType TAG from EC2 instance
+APP_NAME=$( aws ec2 describe-tags --filters "Name=resource-id,Values=${EC2_INSTANCE_ID}" --region ${EC2_REGION} --output text|grep ApplicationType|  awk '{print $5}' | tr '[:upper:]' '[:lower:]' )
+echo "APP_NAME=${APP_NAME}"
+
+INSTANCE_DIR=${NFS_MOUNT_LOCATION}/${APP_NAME}
+echo "INSTANCE_DIR=${INSTANCE_DIR}"
+
+# Get app-instance-name TAG from EC2 instance
+APP_INSTANCE_NAME=$( aws ec2 describe-tags --filters "Name=resource-id,Values=${EC2_INSTANCE_ID}" --region ${EC2_REGION} --output text|grep app-instance-name|  awk '{print $5}' )
+echo "APP_INSTANCE_NAME=${APP_INSTANCE_NAME}"
+
+# Get config base path
+CONFIG_BASE_PATH=$( aws ec2 describe-tags --filters "Name=resource-id,Values=${EC2_INSTANCE_ID}" --region ${EC2_REGION} --output text|grep config-base-path|  awk '{print $5}' )
+echo "CONFIG_BASE_PATH=${CONFIG_BASE_PATH}"

--- a/ansible/roles/lifecycle-scripts/files/update-cron.sh
+++ b/ansible/roles/lifecycle-scripts/files/update-cron.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+### Script to update cronab within the batch container based on crontab.txt file stored in S3 in <image-name>-cron subdir
+### Relies on docker bind mount for crontab dir e.g. /mnt/nfs/chips/chips-ef-batch0/chips-weblogic-batch-cron as <home-dir>/cron
+### Requires values to be supplied as tags on the EC2 instance where it runs:
+###   ApplicationType  (the name of the application type - e.g. cics or chips etc)
+###   app-instance-name  (the name of the application instance type - e.g. cics1 or chips-ef-batch1 etc)
+###   config-base-path (the S3 path to where the config is stored - e.g. s3://shared-services.eu-west-2.configs.ch.gov.uk/cic-configs/development etc)
+### The tags are defined in terraform code and set as values on the launch configuration that is used by the Auto Scaling Group to create EC2 instances.
+
+exec > >(tee -ai ~/updatecron.log) 2>&1
+echo " ~~~~~~~~~ Starting cron update script: `date -u "+%F %T"`"
+
+# set up variables based on aws metadata etc
+. $(dirname $0)/set-aws-vars.sh
+
+# Check S3 and Config can be reached
+aws s3 ls ${CONFIG_BASE_PATH} >/dev/null
+
+if (( $? != 0 )) ; then
+  echo "ERROR - S3 or Config can not be found. Exit. "
+  exit 1
+fi
+
+# Copy config subdirectory content (i.e. crontab) recursively to matching directory
+aws s3 cp ${CONFIG_BASE_PATH}/${APP_INSTANCE_NAME}/ ${INSTANCE_DIR}/${APP_INSTANCE_NAME}/ --recursive
+
+for CRON_DIR in ${INSTANCE_DIR}/${APP_INSTANCE_NAME}/*-cron/; do
+  IMAGE_NAME=$(basename $CRON_DIR | sed 's/-cron//g')
+  CONTAINER_NAME=$(docker ps | awk '{ print $2," ",$NF }' | grep $IMAGE_NAME | awk '{ print $2 }')
+  if [ $(wc -w <<< $CONTAINER_NAME) -gt 1 ]; then
+    echo "ERROR: Skipping cron update for the following containers (based on image $IMAGE_NAME) as multiple containers not expected:"
+    echo "$CONTAINER_NAME"
+  else
+    echo "Updating cron for container $CONTAINER_NAME (based on image $IMAGE_NAME)"
+    docker exec -u weblogic -it $CONTAINER_NAME bash -c "crontab ./cron/crontab.txt"
+    echo "Confirming update - current first line of loaded crontab is:"
+	docker exec -u weblogic -it $CONTAINER_NAME bash -c "crontab -l | head -1"
+  fi
+done

--- a/ansible/roles/lifecycle-scripts/files/weblogic-pre-bootstrap.sh
+++ b/ansible/roles/lifecycle-scripts/files/weblogic-pre-bootstrap.sh
@@ -5,24 +5,7 @@ echo " ~~~~~~~~~ Starting initial steps pre-bootstrap : `date -u "+%F %T"`"
 set -a
 
 echo Load variables from AWS
-NFS_MOUNT_LOCATION="/mnt/nfs"
-EC2_REGION=$( ec2-metadata -z | awk '{print $2}' | sed 's/[a-z]$//' )  #eu-west-2
-
-# Get EC2_INSTANCE_ID  #029a4768b982f1c1d
-EC2_INSTANCE_ID=$( ec2-metadata -i |  awk -F'[: ]' '{print $3}' )
-echo "EC2_INSTANCE_ID=${EC2_INSTANCE_ID}" 
-
-# Get ApplicationType TAG from EC2 instance   #chips
-APP_NAME=$( aws ec2 describe-tags --filters "Name=resource-id,Values=${EC2_INSTANCE_ID}" --region ${EC2_REGION} --output text|grep ApplicationType|  awk '{print $5}' | tr '[:upper:]' '[:lower:]' )
-echo "APP_NAME=${APP_NAME}" 
-
-INSTANCE_DIR=${NFS_MOUNT_LOCATION}/${APP_NAME}
-echo "INSTANCE_DIR=${INSTANCE_DIR}"  #/mnt/nfs/chips
-
-# Get app-instance-name TAG from EC2 instance  APP_INSTANCE_NAME=chips-users-rest0
-APP_INSTANCE_NAME=$( aws ec2 describe-tags --filters "Name=resource-id,Values=${EC2_INSTANCE_ID}" --region ${EC2_REGION} --output text|grep app-instance-name|  awk '{print $5}' )
-echo "APP_INSTANCE_NAME=${APP_INSTANCE_NAME}"
-
+. $(dirname $0)/set-aws-vars.sh
 
 echo delete lok file then move and copy back all servers data store default DAT file
 for SERVER in wladmin wlserver1 wlserver2 wlserver3 wlserver4

--- a/ansible/roles/lifecycle-scripts/tasks/main.yml
+++ b/ansible/roles/lifecycle-scripts/tasks/main.yml
@@ -5,6 +5,18 @@
     dest: "/usr/local/bin/bootstrap"
     mode: 0755
 
+- name: Copy variable setting helper script
+  copy:
+    src: "set-aws-vars.sh"
+    dest: "/usr/local/bin/set-aws-vars.sh"
+    mode: 0755
+
+- name: Copy cron update script
+  copy:
+    src: "update-cron.sh"
+    dest: "/usr/local/bin/update-cron.sh"
+    mode: 0755
+
 - name: Copy dns script
   copy:
     src: "update-dns.sh"


### PR DESCRIPTION
Added support for setting crontab from S3, adding update-cron.sh script.
Script will attempt to update crontab for any container based on an
image with a <image-name>-cron subdir in S3 (requires docker bind
mount to map the resulting dir to $HOME/cron in the container).
Refactored AWS variable setting code into separate set-aws-vars.sh
script to reduce duplication.
Also includes CM-1421 change to update bootstrap script to automatically
prune automatically prune unused docker images.