### PR TITLE
CM-1401 fix to ensure set-aws-vars.sh found

### DIFF
--- a/ansible/roles/lifecycle-scripts/files/boot-strap.sh
+++ b/ansible/roles/lifecycle-scripts/files/boot-strap.sh
@@ -12,7 +12,7 @@ echo " ~~~~~~~~~ Starting Docker Compose wrapper script: `date -u "+%F %T"`"
 set -a
 
 # set up variables based on aws metadata etc
-. $(dirname $0)/set-aws-vars.sh
+. set-aws-vars.sh
 
 # Check S3 and Config can be reached
 aws s3 ls ${CONFIG_BASE_PATH} >/dev/null

--- a/ansible/roles/lifecycle-scripts/files/update-cron.sh
+++ b/ansible/roles/lifecycle-scripts/files/update-cron.sh
@@ -12,7 +12,7 @@ exec > >(tee -ai ~/updatecron.log) 2>&1
 echo " ~~~~~~~~~ Starting cron update script: `date -u "+%F %T"`"
 
 # set up variables based on aws metadata etc
-. $(dirname $0)/set-aws-vars.sh
+. set-aws-vars.sh
 
 # Check S3 and Config can be reached
 aws s3 ls ${CONFIG_BASE_PATH} >/dev/null

--- a/ansible/roles/lifecycle-scripts/files/weblogic-pre-bootstrap.sh
+++ b/ansible/roles/lifecycle-scripts/files/weblogic-pre-bootstrap.sh
@@ -5,7 +5,7 @@ echo " ~~~~~~~~~ Starting initial steps pre-bootstrap : `date -u "+%F %T"`"
 set -a
 
 echo Load variables from AWS
-. $(dirname $0)/set-aws-vars.sh
+. set-aws-vars.sh
 
 echo delete lok file then move and copy back all servers data store default DAT file
 for SERVER in wladmin wlserver1 wlserver2 wlserver3 wlserver4


### PR DESCRIPTION
Fix to take out path to set-aws-vars.sh (relying on PATH var instead) as
the dirname method didn't work when called via su in main.tf