### PR TITLE
Add default docker daemon config

### DIFF
--- a/ansible/host_vars/docker-vm.yaml
+++ b/ansible/host_vars/docker-vm.yaml
@@ -51,3 +51,8 @@ nrpe_command:
     sudo: true
     script: check_docker
     option: $ARG1$
+
+## Docker daemon config
+docker_daemon_config: 
+  log-opts: 
+    max-size: 1g

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -34,6 +34,11 @@
     groups: docker
     append: yes
 
+- name: Set Docker default config
+  copy:
+    dest: /etc/docker/daemon.json
+    content: "{{ docker_daemon_config | to_json }}"
+
 - name: service docker
   service:
     name: docker


### PR DESCRIPTION
Set the max-size of the default log driver (json-file) to 1g to prevent it growing until disk space is exhausted.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1501