### PR TITLE
Add multi-boot-strap.sh script to cater for multiple environments

### DIFF
--- a/ansible/roles/lifecycle-scripts/files/multi-boot-strap.sh
+++ b/ansible/roles/lifecycle-scripts/files/multi-boot-strap.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+### Script to start multiple Docker environments that  is intended for use where there are multiple envionments on a single EC2 instance.
+### Each environment is defined on S3 within a sub-folder under the config-base-path
+### Requires values to be supplied as tags on the EC2 instance where it runs:
+###   ApplicationType  (the name of the application type - e.g. cics or chips etc)
+###   config-base-path (the S3 path to where the config is stored - e.g. s3://shared-services.eu-west-2.configs.ch.gov.uk/cic-configs/development etc)
+### The tags are defined in terraform code and set as values on the launch configuration/template that is used by the Auto Scaling Group to create EC2 instances.
+
+echo " ~~~~~~~~~ Starting Docker Compose multi wrapper script: `date -u "+%F %T"`"
+set -a
+
+# set up variables based on aws metadata etc
+. set-aws-vars.sh
+
+# Check S3 and Config can be reached
+aws s3 ls ${CONFIG_BASE_PATH} >/dev/null
+
+if (( $? != 0 )) ; then
+  echo "ERROR - S3 or Config can not be found. Exit. "
+  exit 1
+fi
+
+# Get a list of environments by listing the sub-folders under ${CONFIG_BASE_PATH}
+ENVIRONMENTS=$(aws s3 ls ${CONFIG_BASE_PATH}/ | grep PRE | awk '{print $2}' | tr -d '/')
+
+for ENVIRONMENT in ${ENVIRONMENTS}
+do
+  ./bootstrap ${ENVIRONMENT} &
+done
+
+

--- a/ansible/roles/lifecycle-scripts/tasks/main.yml
+++ b/ansible/roles/lifecycle-scripts/tasks/main.yml
@@ -5,6 +5,12 @@
     dest: "/usr/local/bin/bootstrap"
     mode: 0755
 
+- name: Copy multi bootstrap script
+  copy:
+    src: "multi-boot-strap.sh"
+    dest: "/usr/local/bin/multi-bootstrap"
+    mode: 0755
+
 - name: Copy variable setting helper script
   copy:
     src: "set-aws-vars.sh"


### PR DESCRIPTION
Support multiple docker environments on a single EC2 instance.

Adds a multi-boot-start.sh script that enumerates the "sub-folders" under the base config path in S3 and calls the bootstrap script for each, passing the environment name as a parameter.
The boot-strap.sh script has been updated to allow override of the APP_INSTANCE_NAME from the supplied parameter, as well as creating a dedicated log file if a parameter is supplied.

Partially resolves:
https://companieshouse.atlassian.net/browse/CM-1511

