### PR TITLE
Correct the path to the bootstrap script

### DIFF
--- a/ansible/roles/lifecycle-scripts/files/multi-boot-strap.sh
+++ b/ansible/roles/lifecycle-scripts/files/multi-boot-strap.sh
@@ -26,7 +26,7 @@ ENVIRONMENTS=$(aws s3 ls ${CONFIG_BASE_PATH}/ | grep PRE | awk '{print $2}' | tr
 
 for ENVIRONMENT in ${ENVIRONMENTS}
 do
-  ./bootstrap ${ENVIRONMENT} &
+  bootstrap ${ENVIRONMENT} &
 done
 
 


### PR DESCRIPTION
The path was incorrect to the bootstrap script - it is on the PATH and so shouldn't be referenced as if it was a file in the same location.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1511