### PR TITLE
Set python interpreter to /usr/bin/python3

### DIFF
--- a/ansible/roles/appdynamics-machine-agent/tasks/main.yml
+++ b/ansible/roles/appdynamics-machine-agent/tasks/main.yml
@@ -13,6 +13,8 @@
     group: ec2-user   
     
 - name: Download agent from S3
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   amazon.aws.aws_s3:
     bucket: "{{ aws_s3_dev_resources_bucket }}"
     object: "packages/appdynamics/machineagent-bundle-64bit-linux-{{ agent_version }}.zip"


### PR DESCRIPTION
Add a role to download and install the App Dynamics machine agent as part of the AMI build.

Partially resolves:
https://companieshouse.atlassian.net/browse/CM-1542
