### PR TITLE
Use gp3 storage by default

### DIFF
--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -11,7 +11,6 @@ source "amazon-ebs" "builder" {
 
   launch_block_device_mappings {
     device_name = "/dev/xvda"
-    encrypted   = true
     volume_size = var.root_volume_size_gb
     volume_type = "gp3"
     delete_on_termination = true
@@ -22,7 +21,6 @@ source "amazon-ebs" "builder" {
 
     content {
       device_name = var.swap_volume_device_node
-      encrypted   = true
       volume_size = var.swap_volume_size_gb
       volume_type = "gp3"
       delete_on_termination = true

--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -13,7 +13,7 @@ source "amazon-ebs" "builder" {
     device_name = "/dev/xvda"
     encrypted   = true
     volume_size = var.root_volume_size_gb
-    volume_type = "gp2"
+    volume_type = "gp3"
     delete_on_termination = true
   }
 
@@ -24,7 +24,7 @@ source "amazon-ebs" "builder" {
       device_name = var.swap_volume_device_node
       encrypted   = true
       volume_size = var.swap_volume_size_gb
-      volume_type = "gp2"
+      volume_type = "gp3"
       delete_on_termination = true
     }
   }

--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -11,6 +11,7 @@ source "amazon-ebs" "builder" {
 
   launch_block_device_mappings {
     device_name = "/dev/xvda"
+    encrypted   = true
     volume_size = var.root_volume_size_gb
     volume_type = "gp2"
     delete_on_termination = true
@@ -21,6 +22,7 @@ source "amazon-ebs" "builder" {
 
     content {
       device_name = var.swap_volume_device_node
+      encrypted   = true
       volume_size = var.swap_volume_size_gb
       volume_type = "gp2"
       delete_on_termination = true


### PR DESCRIPTION
Update from gp2 to gp3.   The encryption  of volums will be done in each CHIPS service's terraform instead of enabling it on the AMI build.

Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2731