### PR TITLE
Use ec2-metadata command instead of curl to access metadata

### DIFF
--- a/ansible/roles/lifecycle-scripts/files/update-dns.sh
+++ b/ansible/roles/lifecycle-scripts/files/update-dns.sh
@@ -20,6 +20,6 @@ if [ -z "${FQDN}" ]; then
   exit 1
 fi
 
-IP=$( curl http://169.254.169.254/latest/meta-data/local-ipv4 )
+IP=$( ec2-metadata -o | awk '{print $2}' )
 echo "{ \"Comment\": \"UPSERT host record for ${FQDN}\", \"Changes\": [{ \"Action\": \"UPSERT\", \"ResourceRecordSet\": { \"Name\": \"${FQDN}\", \"Type\": \"A\", \"TTL\": 60, \"ResourceRecords\": [{ \"Value\": \"${IP}\"}] }}] }" > dns.json
 aws route53 change-resource-record-sets --hosted-zone-id ${ZONE_ID} --change-batch file://dns.json


### PR DESCRIPTION
Use ec2-metadata command rather than curl to access the ip, so that it works with IMDSv2, where http tokens are required.

Resolves:
https://companieshouse.atlassian.net/browse/DVOP-2731