### PR TITLE
Adjust network address pools to avoid clash with other networks

### DIFF
--- a/ansible/host_vars/docker-vm.yaml
+++ b/ansible/host_vars/docker-vm.yaml
@@ -56,3 +56,6 @@ nrpe_command:
 docker_daemon_config: 
   log-opts: 
     max-size: 1g
+  default-address-pools:
+    - base: 172.17.0.0/16
+      size: 24


### PR DESCRIPTION
Changes the distribution of networks created by docker to increase capacity and avoid a clash with another network that is in use.

Previously, a new network address was allocated for each docker network, as follows:
172.18.x.x
172.19.x.x
...
172.23.x.x
172.24.x.x <--- clash with a non-docker network

This changes the distribution, so that the networks are now:
172.17.0.x
172.17.1.x
172.17.2.x
etc

This allows 256 networks, each with 256 containers.