### PR TITLE
Add lookup-secrets.sh script and call from bootstrap script

### DIFF
--- a/ansible/roles/lifecycle-scripts/files/boot-strap.sh
+++ b/ansible/roles/lifecycle-scripts/files/boot-strap.sh
@@ -41,6 +41,9 @@ cd ${INSTANCE_DIR}/${APP_INSTANCE_NAME}
 aws s3 cp ${CONFIG_BASE_PATH}/ ./ --recursive --exclude "*/*"
 aws s3 cp ${CONFIG_BASE_PATH}/${APP_INSTANCE_NAME}/ ./ --recursive
 
+# Process any properties files to lookup parameter store values
+lookup-secrets.sh
+
 # Get and source application versions to use for Docker Compose
 # Also soruces any additional vars set in app-image-versions, such as APP_INSTANCE_NUMBER
 . app-image-versions

--- a/ansible/roles/lifecycle-scripts/files/lookup-secrets.sh
+++ b/ansible/roles/lifecycle-scripts/files/lookup-secrets.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Searches the current working directory for any files named *.properties and
+# looks up values from parameter store. It only searches at the current level
+# and does not descend into sub-directories.
+#
+# It looks for values in the properties like MY_VAR="@/chips/env/path/to/secret" and 
+# replaces the path with the value held in parameter store (if it is available)
+
+function processPropertyFile() {
+  PROPERTIES_FILE=$1
+
+  # Get list of param store paths from the properties file
+  PATHS_TO_LOOKUP=$( grep "@/" ${PROPERTIES_FILE} | sed 's/.*["'\'']@\(\/.*\)["'\'']$/\1/g' )
+
+  for PATH_TO_LOOKUP in ${PATHS_TO_LOOKUP}
+  do
+    echo "Looking up ${PATH_TO_LOOKUP} found in ${PROPERTIES_FILE}"
+    VALUE=$( aws ssm get-parameter --with-decryption --region ${EC2_REGION} --output text --query Parameter.Value --name ${PATH_TO_LOOKUP} 2> /dev/null )
+    EXIT_CODE=$?
+
+    if [[ EXIT_CODE -eq 0 ]]; then
+      ESCAPED_VALUE=$( printf '%s\n' "${VALUE}" | sed -e 's/[\/&]/\\&/g' )
+      ESCAPED_PATH=$( printf '%s\n' "${PATH_TO_LOOKUP}" | sed -e 's/[]\/$*.^[]/\\&/g' )
+      sed -i "s/@${ESCAPED_PATH}/${ESCAPED_VALUE}/g" ${PROPERTIES_FILE}
+    elif [[ EXIT_CODE -eq 255 ]]; then
+      echo "No value found for path ${PATH_TO_LOOKUP}"
+    else
+      echo "Error looking up path ${PATH_TO_LOOKUP}"
+    fi
+  done
+}
+
+for PROPERTY_FILE in *.properties
+do
+  if [[ -f ${PROPERTY_FILE} ]]; then
+    processPropertyFile ${PROPERTY_FILE}
+  fi
+done

--- a/ansible/roles/lifecycle-scripts/tasks/main.yml
+++ b/ansible/roles/lifecycle-scripts/tasks/main.yml
@@ -17,6 +17,12 @@
     dest: "/usr/local/bin/set-aws-vars.sh"
     mode: 0755
 
+- name: Copy lookup-secrets.sh script
+  copy:
+    src: "lookup-secrets.sh"
+    dest: "/usr/local/bin/lookup-secrets.sh"
+    mode: 0755
+
 - name: Copy cron update script
   copy:
     src: "update-cron.sh"


### PR DESCRIPTION
Adds function to scan top-level *.properties files (after download from S3) for any values of a special syntax that indicates they should be retrieved from parameter store.  Each property will then be updated to have the value from parameter store if the path is valid.

E.g. if the property was:
`MY_ENV_VAR="@/chips/env/path/to/secret"`
the result would be
`MY_ENV_VAR="my secret"`

If there are no property files, or no path values found inside any properties, then the function does nothing so that it is backwards compatible.

Resolves
https://companieshouse.atlassian.net/browse/CHP-61