### PR TITLE
Provide uppercased APP_INSTANCE_NAME as new var APP_INSTANCE_NAME_UPPER

### DIFF
--- a/ansible/roles/lifecycle-scripts/files/boot-strap.sh
+++ b/ansible/roles/lifecycle-scripts/files/boot-strap.sh
@@ -33,6 +33,9 @@ if [ ! -z  "$1" ]; then
   APP_INSTANCE_NAME=$1
 fi
 
+# Provide uppercase APP_INSTANCE_NAME
+APP_INSTANCE_NAME_UPPER="${APP_INSTANCE_NAME^^}"
+
 # create server instance directory
 mkdir -p ${INSTANCE_DIR}/${APP_INSTANCE_NAME}/running-servers
 cd ${INSTANCE_DIR}/${APP_INSTANCE_NAME}


### PR DESCRIPTION
Add another var APP_INSTANCE_NAME_UPPER which is just the uppercase version of the APP_INSTANCE_NAME.

This is useful with the E2E environments.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-63