### PR TITLE
Support optional service list var and avoid pruning images < 7 days old

### DIFF
--- a/ansible/roles/lifecycle-scripts/files/boot-strap.sh
+++ b/ansible/roles/lifecycle-scripts/files/boot-strap.sh
@@ -66,8 +66,8 @@ set +a
 
 ### Prune docker images
 echo "Pruning all docker images not currently in use ..."
-docker image prune -a --force
+docker image prune -a --force --filter "until=168h"
 
 ### RUN DOCKER COMPOSE
 echo "Starting docker compose file ..."
-docker-compose up -d
+docker-compose up -d ${BOOTSTRAP_SERVICE_LIST}


### PR DESCRIPTION
Enhances the bootstrap script to allow an optional `BOOTSTRAP_SERVICE_LIST` env var, that is added as a suffix on the `docker-compose up -d` command.  This allows control of which compose services are refreshed/restarted, instead of always doing all of them.  The default behaviour is preserved if the var is empty or not set.

Also updates the prune of old images so that it retains any which are younger than 7 days.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-708