### PR TITLE
Add set-container-alias.sh script

### DIFF
--- a/ansible/roles/lifecycle-scripts/files/set-container-alias.sh
+++ b/ansible/roles/lifecycle-scripts/files/set-container-alias.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+### Script to set a Docker container alias in the .bashrc file for running bash
+### in a specific Docker service container as a specific user.
+### This script can be run on EC2 instance startup in a similar way to the bootstrap script.
+###
+### This takes 3 parameters:
+### 1. ALIAS: The alias name to be set
+### 2. SERVICE: The Docker service name (e.g., build, batch, etc.)
+### 3. USER: The user to use to enter the container
+
+LOG_FILE=~/setalias.log
+
+exec > >(tee -ai ${LOG_FILE}) 2>&1
+echo " ~~~~~~~~~ Setting container alias $1 $2 $3: `date -u "+%F %T"`"
+
+# Check there are 3 params supplied
+if [ $# -ne 3 ]; then
+    echo "Expecting 3 params: ALIAS SERVICE USER"
+    echo "E.g.: set-container-alias.sh oltp oltp-batch oltp"
+    echo "would result in the alias alias oltp='docker exec -it -u oltp \${APP_INSTANCE_NAME}-oltp-batch-1 bash' being added to .bashrc"
+    # exit with error code 0 as this is not a failure that should stop the instance from starting
+    exit 0
+fi
+ALIAS=$1
+SERVICE=$2
+USER=$3
+
+# set up variables based on aws metadata etc
+. set-aws-vars.sh
+echo "alias ${ALIAS}='docker exec -it -u ${USER} ${APP_INSTANCE_NAME}-${SERVICE}-1 bash'" >> .bashrc
+
+echo " ~~~~~~~~~ Finished setting container alias : `date -u "+%F %T"`"

--- a/ansible/roles/lifecycle-scripts/tasks/main.yml
+++ b/ansible/roles/lifecycle-scripts/tasks/main.yml
@@ -23,6 +23,12 @@
     dest: "/usr/local/bin/load-cached-images.sh"
     mode: 0755
 
+- name: Copy set-container-alias script
+  copy:
+    src: "set-container-alias.sh"
+    dest: "/usr/local/bin/set-container-alias.sh"
+    mode: 0755
+
 - name: Copy lookup-secrets.sh script
   copy:
     src: "lookup-secrets.sh"


### PR DESCRIPTION
Adds a fairly generic script that we can call on EC2 instance startup to set up a useful alias for entering a container.  The script can be called multiple times, setting an additional alias each time.

E.g. `set-container-alias.sh build build weblogic` would add an alias so that we could enter the build container by just typing `build`, which is a lot easier than something like `docker exec -it -u weblogic cidev-build-1 bash`.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-741
