### PR TITLE
Pin docker-compose version to 2.39.1

### DIFF
--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -47,7 +47,7 @@
 
 - name: Download docker-compose binary
   get_url:
-    url: https://github.com/docker/compose/releases/latest/download/docker-compose-Linux-x86_64
+    url: https://github.com/docker/compose/releases/download/v2.39.1/docker-compose-linux-x86_64
     dest: /usr/local/bin/docker-compose
     mode: '0755'
 


### PR DESCRIPTION
Fix the version of the docker-compose binary that is downloaded.

Resolves
https://companieshouse.atlassian.net/browse/CHP-903